### PR TITLE
Removing breakpoint mixin

### DIFF
--- a/_breakpoints.scss
+++ b/_breakpoints.scss
@@ -1,7 +1,0 @@
-// BREAKPOINTS
-@mixin bp($val) {
-
-	// Just use foundation's breakpoint mixin
-	@include breakpoint($val);
-
-}


### PR DESCRIPTION
This just causes an error. We will just use Foundation’s.
